### PR TITLE
Return message values as string if there's a leading zero

### DIFF
--- a/src/PAMI/Message/Message.php
+++ b/src/PAMI/Message/Message.php
@@ -138,6 +138,11 @@ abstract class Message
         if (!isset($value) || $value === null || strlen($value) == 0) {
             return null;
         } elseif (is_numeric($value)) {
+            // index access is safe as is_numeric('') === false
+            if ($value[0] === '0') {
+                // Return as string if there's a leading zero to avoid losing information
+                return $value;
+            }
             if (filter_var($value, FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_HEX | FILTER_FLAG_ALLOW_OCTAL)) {
                 return intval($value, 0);
             }


### PR DESCRIPTION
Avoids losing information e.g. with extensions that have leading zeroes.