### PR TITLE
Fix order arguments for implode()

### DIFF
--- a/src/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
+++ b/src/PAMI/Message/Event/Factory/Impl/EventFactoryImpl.php
@@ -70,7 +70,7 @@ class EventFactoryImpl
         for ($i = 0; $i < $totalParts; $i++) {
             $parts[$i] = ucfirst($parts[$i]);
         }
-        $name = implode($parts, '');
+        $name = implode('', $parts);
         $className = '\\PAMI\\Message\\Event\\' . $name . 'Event';
         if (class_exists($className, true)) {
             return new $className($message);


### PR DESCRIPTION
Deprecated: implode(): Passing glue string after array is deprecated. Swap the parameters in ...