### PR TITLE
Return message values as string if there's a leading plus sign

### DIFF
--- a/src/PAMI/Message/Message.php
+++ b/src/PAMI/Message/Message.php
@@ -139,8 +139,8 @@ abstract class Message
             return null;
         } elseif (is_numeric($value)) {
             // index access is safe as is_numeric('') === false
-            if ($value[0] === '0') {
-                // Return as string if there's a leading zero to avoid losing information
+            if ($value[0] === '0' || $value[0] === '+') {
+                // Return as string if there's a leading zero or plus sign to avoid losing information
                 return $value;
             }
             if (filter_var($value, FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_HEX | FILTER_FLAG_ALLOW_OCTAL)) {


### PR DESCRIPTION
Avoids losing information e.g. when having numbers in international e.123 format which have a leading plus sign.