### PR TITLE
Fixed filter deprecations on PHP 8.1

### DIFF
--- a/src/PAMI/Message/Message.php
+++ b/src/PAMI/Message/Message.php
@@ -159,7 +159,7 @@ abstract class Message
             if (strcasecmp($value, 'off') === 0 || strcasecmp($value, 'false') === 0 || strcasecmp($value, 'no') === 0) {
                 return (boolean)false;
             }
-            if (filter_var($value, FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE)) {
+            if (filter_var($value, FILTER_UNSAFE_RAW, FILTER_NULL_ON_FAILURE)) {
                 return (string)htmlspecialchars($value, ENT_QUOTES);
             }
             throw new PAMIException("Incoming String is not sanitary. Skipping: '" . $value . "'\n");

--- a/src/PAMI/Message/Message.php
+++ b/src/PAMI/Message/Message.php
@@ -159,9 +159,6 @@ abstract class Message
             if (strcasecmp($value, 'off') === 0 || strcasecmp($value, 'false') === 0 || strcasecmp($value, 'no') === 0) {
                 return (boolean)false;
             }
-            if (filter_var($value, FILTER_SANITIZE_STRING, FILTER_NULL_ON_FAILURE)) {
-                return (string)$value;
-            }
             if (filter_var($value, FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_NULL_ON_FAILURE)) {
                 return (string)htmlspecialchars($value, ENT_QUOTES);
             }


### PR DESCRIPTION
Removes deprecated on PHP 8.1 constant `FILTER_SANITIZE_STRING` usage.

Replaces undocumented `FILTER_SANITIZE_FULL_SPECIAL_CHARS` usage by common `FILTER_UNSAFE_RAW` filter.

Closes #22 

More info about migration from `FILTER_SANITIZE_STRING` constant on Stack Overflow:
https://stackoverflow.com/a/69207369/5533907